### PR TITLE
use routerlink and link to keep navigation in-app

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push, pull_request]
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/src/pages/home/Home.css
+++ b/src/pages/home/Home.css
@@ -5,3 +5,7 @@
 hr.divider {
   border-top: 1px solid var(--ion-color-medium-tint);
 }
+
+a.link-plain {
+  text-decoration: none;
+}

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -5,7 +5,6 @@ import {
   IonGrid,
   IonRow,
   IonCol,
-  IonRouterLink,
   IonButton,
   IonList,
   IonIcon,
@@ -14,6 +13,7 @@ import { people, document, documents } from 'ionicons/icons';
 import './Home.css';
 import data from "../../assets/data/data.json";
 import { TopicItem } from '../../components/topic';
+import { Link } from "react-router-dom";
 
 const Home: React.FC = () => {
   const guides = data.topics;
@@ -31,13 +31,13 @@ const Home: React.FC = () => {
               <h5 className="section-heading">The Constitution</h5>
             </IonCol>
             <IonCol size="1">
-              <IonRouterLink class="ion-float-right" href="/search/constitution">Search</IonRouterLink>
+              <Link className="ion-float-right link-plain" to="/search/constitution">Search</Link>
             </IonCol>
           </IonRow>
         </IonGrid>
 
         <div className="ion-padding-bottom">Browse the Constitution for the provisions that you need.</div>
-        <IonButton href="/constitution" expand="block">Browse Sections</IonButton>
+        <IonButton routerLink="/constitution" expand="block">Browse Sections</IonButton>
 
         <hr className="divider" />
 
@@ -50,7 +50,7 @@ const Home: React.FC = () => {
               <h5 className="section-heading">Guides</h5>
             </IonCol>
             <IonCol size="1">
-              <IonRouterLink class="ion-float-right" href="/search/guides">Search</IonRouterLink>
+              <Link className="ion-float-right link-plain" to="/search/guides">Search</Link>
             </IonCol>
           </IonRow>
         </IonGrid>
@@ -63,7 +63,7 @@ const Home: React.FC = () => {
             <TopicItem topic={guide} />
           ))}
         </IonList>
-        <IonButton href="/guides" expand="block">Browse All Guides</IonButton>
+        <IonButton routerLink="/guides" expand="block">Browse All Guides</IonButton>
 
         <hr className="divider" />
 
@@ -76,7 +76,7 @@ const Home: React.FC = () => {
               <h5 className="section-heading">Cases</h5>
             </IonCol>
             <IonCol size="1" className="ion-text-nowrap">
-              <IonRouterLink class="ion-float-right" href="/cases">Browse All</IonRouterLink>
+              <Link className="ion-float-right link-plain" to="/cases/">Browse All</Link>
             </IonCol>
           </IonRow>
         </IonGrid>
@@ -85,7 +85,7 @@ const Home: React.FC = () => {
           See how the courts have interpreted the Constitution by reading the leading cases on constitutional
           provisions.
         </div>
-        <IonButton href="/search/cases" expand="block">Search Cases</IonButton>
+        <IonButton routerLink="/search/cases" expand="block">Search Cases</IonButton>
 
         <hr className="divider" />
 
@@ -105,7 +105,7 @@ const Home: React.FC = () => {
           </IonRow>
         </IonGrid>
 
-        <IonButton href="/help" expand="block">About This App</IonButton>
+        <IonButton routerLink="/help" expand="block">About This App</IonButton>
       </IonContent>
     </IonPage>
   );


### PR DESCRIPTION
Turns out that without this, the links are followed as regular links, which fails.

The docs for IonRouterLink say it should only be used for static apps, and suggest Link and IonButton instead.