### PR TITLE
Virtualize Large Lists to improve performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@types/react-dom": "^16.9.4",
     "@types/react-router": "^5.1.4",
     "@types/react-router-dom": "^5.1.3",
+    "@types/react-virtualized-auto-sizer": "^1.0.1",
+    "@types/react-window": "^1.8.5",
     "html-react-parser": "^0.14.0",
     "ionicons": "^5.0.0",
     "lunr": "^2.3.9",
@@ -28,6 +30,8 @@
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.0",
+    "react-virtualized-auto-sizer": "^1.0.6",
+    "react-window": "^1.8.6",
     "sass": "^1.35.2",
     "typescript": "3.8.3"
   },

--- a/src/common-types.ts
+++ b/src/common-types.ts
@@ -1,0 +1,16 @@
+/*---- File for common types and interfaces ---*/
+
+export interface TOCItem {
+  [key: string]: any; // type for unknown keys.
+  children?: TOCItem[];
+}
+
+export type CallbackType = (...arg: string[]) => void;
+
+
+export type RowPropsType = {
+  index: number,
+  setSize: CallbackType,
+  windowWidth: number,
+  data: TOCItem[]
+}

--- a/src/components/constitutionTOC.tsx
+++ b/src/components/constitutionTOC.tsx
@@ -1,6 +1,35 @@
 import React from "react";
 import { IonItem } from "@ionic/react";
 import { toc } from "../data/constitution";
+import { VariableSizeList as List } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { useWindowResize } from "../hooks/useWindowResize";
+import { RowPropsType } from "../common-types";
+
+interface TOCItemProps {
+  item: any;
+  onClick?: any;
+}
+
+const TOCItem: React.FC<TOCItemProps> = ({ item, onClick }) => {
+  const kids = (item.children || []).filter((c: any) => c.id);
+  const props = onClick ? {onClick: () => onClick(item)} : {routerLink: '/constitution/provision/' + item.id};
+
+  return (
+      <div>
+        <IonItem class={item.type === "chapter" ? "chapter" : ""} {...props}>
+          {item.title}
+        </IonItem>
+        {kids.length > 0 && (
+            <div className="ion-padding-start">
+              {kids.map((child: any) => {
+                return <TOCItem key={child.id} item={child} onClick={onClick} />;
+              })}
+            </div>
+        )}
+      </div>
+  );
+};
 
 interface TOCListProps {
   onClick?: any;
@@ -10,40 +39,66 @@ interface TOCListProps {
 const provisions = toc.items.filter((c: any) => c.id);
 
 export const TOCList: React.FC<TOCListProps> = ({ onClick }) => {
+  const Row = ({ index, setSize, data, windowWidth }: RowPropsType ) => {
+    const rowRef = React.useRef<HTMLElement | null>(null);
+    React.useEffect(() => {
+      if(rowRef && rowRef.current) {
+        // @ts-ignore
+        setSize(String(index), rowRef.current.getBoundingClientRect().height);
+      }
+    }, [setSize, index, windowWidth]);
+    return (
+        <div
+            // @ts-ignore
+            ref={rowRef}
+        >
+          <TOCItem
+              item={data[index]}
+              onClick={onClick}
+          />
+        </div>
+    )
+  };
+
+  const listRef = React.useRef(null);
+  const sizeMap = React.useRef({});
+  const setSize = React.useCallback((index, size) => {
+    sizeMap.current = { ...sizeMap.current, [index]: size };
+    // @ts-ignore
+    listRef.current.resetAfterIndex(index);
+  }, []);
+  // @ts-ignore
+  const getSize = index => sizeMap.current[index] || 50;
+  const [windowWidth] = useWindowResize();
+
+  // only render provisions with ids
+  const provisions = React.useMemo(
+      () => toc.items.filter((c: any) => c.id),
+      []
+  );
+
   return (
       <div>
-        {provisions.map((item: any) => {
-          return (
-              <div key={item.id}>
-                <TOCItem item={item} onClick={onClick}/>
+        <List
+            ref={listRef}
+            className="List"
+            height={500}
+            itemCount={provisions.length}
+            itemData={provisions}
+            itemSize={getSize}
+            width="100%"
+        >
+          {({ data, index, style }) => (
+              <div style={style}>
+                <Row
+                    index={index}
+                    setSize={setSize}
+                    windowWidth={windowWidth}
+                    data={data}
+                />
               </div>
-          );
-        })}
+          )}
+        </List>
       </div>
-  );
-};
-
-interface TOCItemProps {
-  item: any;
-  onClick?: any;
-}
-
-export const TOCItem: React.FC<TOCItemProps> = ({ item, onClick }) => {
-  const kids = (item.children || []).filter((c: any) => c.id);
-  const props = onClick ? {onClick: () => onClick(item)} : {routerLink: '/constitution/provision/' + item.id};
-
-  return (
-    <div>
-      <IonItem class={item.type === "chapter" ? "chapter" : ""} {...props}>
-        {item.title}
-      </IonItem>
-      {kids.length > 0 && (
-        <div className="ion-padding-start">
-          {kids.map((child: any) => {
-            return <TOCItem key={child.id} item={child} onClick={onClick} />;
-          })}
-        </div>
-      )}
-    </div>
   );
 };

--- a/src/components/rulesTOC.tsx
+++ b/src/components/rulesTOC.tsx
@@ -1,24 +1,76 @@
 import React from "react";
 import { IonItem } from "@ionic/react";
 import { toc } from "../data/rules";
+import { VariableSizeList as List } from "react-window";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { useWindowResize } from "../hooks/useWindowResize";
+import { RowPropsType } from "../common-types";
 
 interface TOCListProps {
   onClick?: any;
 }
 
-// only render provisions with ids
-const provisions = toc.items.filter((c: any) => c.id);
-
 export const TOCList: React.FC<TOCListProps> = ({ onClick }) => {
+
+  const Row = ({ index, setSize, data, windowWidth }: RowPropsType ) => {
+    const rowRef = React.useRef<HTMLElement | null>(null);
+    React.useEffect(() => {
+      if(rowRef && rowRef.current) {
+        // @ts-ignore
+        setSize(String(index), rowRef.current.getBoundingClientRect().height);
+      }
+    }, [setSize, index, windowWidth])
+    return (
+        <div
+            // @ts-ignore
+            ref={rowRef}
+        >
+          <RuleTOCItem
+              item={data[index]}
+              onClick={onClick}
+          />
+        </div>
+    )
+  };
+
+  const listRef = React.useRef(null);
+  const sizeMap = React.useRef({});
+  const setSize = React.useCallback((index, size) => {
+    sizeMap.current = { ...sizeMap.current, [index]: size };
+    // @ts-ignore
+    listRef.current.resetAfterIndex(index);
+  }, []);
+  // @ts-ignore
+  const getSize = index => sizeMap.current[index] || 50;
+  const [windowWidth] = useWindowResize();
+
+  // only render provisions with ids
+  const provisions = React.useMemo(
+      () => toc.items.filter((c: any) => c.id),
+      []
+  );
   return (
       <div>
-        {provisions.map((item: any) => {
-          return (
-              <div key={item.id}>
-                <RuleTOCItem item={item} onClick={onClick}/>
+        <List
+            ref={listRef}
+            className="List"
+            height={500}
+            itemCount={provisions.length}
+            itemData={provisions}
+            itemSize={getSize}
+            width="100%"
+        >
+          {({ data, index, style }) => (
+              <div style={style}>
+                <Row
+                    index={index}
+                    setSize={setSize}
+                    windowWidth={windowWidth}
+                    data={data}
+                />
               </div>
-          );
-        })}
+          )}
+        </List>
       </div>
   );
 };

--- a/src/data/toc.ts
+++ b/src/data/toc.ts
@@ -2,12 +2,14 @@ export class TableOfContents {
   public items: any[];
   public itemsById: Map<string, any>;
   public flattened: string[];
+  public flattenedDeep: any[];
 
   constructor(items: any[]) {
     this.items = items;
     this.itemsById = new Map();
     this.indexItems(items, null);
     this.flattened = flattenTOC(items);
+    this.flattenedDeep = flattenedDeep(items);
   }
 
   /** Mapping from toc element id to toc entry
@@ -54,3 +56,16 @@ function flattenTOC(arr: any[]) {
   return result;
 }
 
+// @ts-ignore
+function flattenedDeep(array: any[]) {
+  let children: string | any[] = [];
+  return array.map(item => {
+    if (item.children && item.children.length) {
+      item.isParent = true;
+      // @ts-ignore
+      children = [...children, ...item.children];
+    }
+    return item;
+    // @ts-ignore
+  }).concat(children.length ? flattenedDeep(children) : children);
+}

--- a/src/data/toc.ts
+++ b/src/data/toc.ts
@@ -55,17 +55,3 @@ function flattenTOC(arr: any[]) {
 
   return result;
 }
-
-// @ts-ignore
-function flattenedDeep(array: any[]) {
-  let children: string | any[] = [];
-  return array.map(item => {
-    if (item.children && item.children.length) {
-      item.isParent = true;
-      // @ts-ignore
-      children = [...children, ...item.children];
-    }
-    return item;
-    // @ts-ignore
-  }).concat(children.length ? flattenedDeep(children) : children);
-}

--- a/src/hooks/useWindowResize.tsx
+++ b/src/hooks/useWindowResize.tsx
@@ -1,0 +1,18 @@
+import { useState, useLayoutEffect } from "react";
+
+export const useWindowResize = () => {
+  const [size, setSize] = useState([0, 0]);
+
+  useLayoutEffect(() => {
+    function updateSize() {
+      setSize([window.innerWidth, window.innerHeight]);
+    }
+
+    window.addEventListener("resize", updateSize);
+    updateSize();
+
+    return () => window.removeEventListener("resize", updateSize);
+  }, []);
+
+  return size;
+};

--- a/src/pages/topics/Topics.tsx
+++ b/src/pages/topics/Topics.tsx
@@ -36,11 +36,11 @@ const Topics: React.FC = () => {
           <p>Guides to the sections of the Constitution.</p>
           <hr className="list-divider" />
         </div>
-        <IonList className="ion-padding">
-          {data.topics.map((topic) => (
-            <TopicItem topic={topic} key={topic.id} />
-          ))}
-        </IonList>
+        {/*<IonList className="ion-padding">*/}
+        {/*  {data.topics.map((topic) => (*/}
+        {/*    <TopicItem topic={topic} key={topic.id} />*/}
+        {/*  ))}*/}
+        {/*</IonList>*/}
       </IonContent>
     </IonPage>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,6 +1806,20 @@
     "@types/history" "*"
     "@types/react" "*"
 
+"@types/react-virtualized-auto-sizer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz#b3187dae1dfc4c15880c9cfc5b45f2719ea6ebd4"
+  integrity sha512-GH8sAnBEM5GV9LTeiz56r4ZhMOUSrP43tAQNSRVxNexDjcNKLCEtnxusAItg1owFUFE6k0NslV26gqVClVvong==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-window@^1.8.5":
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-window/-/react-window-1.8.5.tgz#285fcc5cea703eef78d90f499e1457e9b5c02fc1"
+  integrity sha512-V9q3CvhC9Jk9bWBOysPGaWy/Z0lxYcTXLtLipkt2cnRj1JOSFNF7wqGpkScSXMgBwC+fnVRg/7shwgddBG5ICw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.9.17":
   version "16.9.55"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.55.tgz#47078587f5bfe028a23b6b46c7b94ac0d436acff"
@@ -7112,6 +7126,11 @@ mem@^4.0.0:
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
 
+"memoize-one@>=3.1.1 <6":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -9259,6 +9278,19 @@ react-scripts@3.4.0:
     workbox-webpack-plugin "4.3.1"
   optionalDependencies:
     fsevents "2.1.2"
+
+react-virtualized-auto-sizer@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.6.tgz#66c5b1c9278064c5ef1699ed40a29c11518f97ca"
+  integrity sha512-7tQ0BmZqfVF6YYEWcIGuoR3OdYe8I/ZFbNclFlGOC3pMqunkYF/oL30NCjSGl9sMEb17AnzixDz98Kqc3N76HQ==
+
+react-window@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/react-window/-/react-window-1.8.6.tgz#d011950ac643a994118632665aad0c6382e2a112"
+  integrity sha512-8VwEEYyjz6DCnGBsd+MgkD0KJ2/OXFULyDtorIiTz+QzwoP94tBoA7CnbtyXMm+cCeAUER5KJcPtWl9cpKbOBg==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    memoize-one ">=3.1.1 <6"
 
 react@^16.13.0:
   version "16.14.0"


### PR DESCRIPTION
- Applied to logic to TOC List views to only render items of table of contents that are within screen view. to improve performance 
There is an improvement testing on mobile so far but need to iron out more kinks
Referencing this article
https://javascript.plainenglish.io/how-to-handle-large-amounts-of-data-in-a-list-on-the-frontend-80725661ff51